### PR TITLE
Add unique entry point for extra tests

### DIFF
--- a/.github/actions/apt-x32/action.yml
+++ b/.github/actions/apt-x32/action.yml
@@ -6,6 +6,8 @@ runs:
       run: |
         set -x
 
+        OPCACHE_TLS_TESTS_DEPS="gcc clang lld"
+
         export DEBIAN_FRONTEND=noninteractive
         dpkg --add-architecture i386
         apt-get update -y | true
@@ -50,4 +52,5 @@ runs:
           re2c \
           unzip \
           wget \
-          zlib1g-dev:i386
+          zlib1g-dev:i386 \
+          $OPCACHE_TLS_TESTS_DEPS

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -6,6 +6,8 @@ runs:
       run: |
         set -x
 
+        OPCACHE_TLS_TESTS_DEPS="gcc clang lld"
+
         sudo apt-get update
         sudo apt-get install \
           bison \
@@ -58,4 +60,5 @@ runs:
           libqdbm-dev \
           libjpeg-dev \
           libpng-dev \
-          libfreetype6-dev
+          libfreetype6-dev \
+          $OPCACHE_TLS_TESTS_DEPS

--- a/.github/actions/extra-tests/action.yml
+++ b/.github/actions/extra-tests/action.yml
@@ -1,0 +1,7 @@
+name: Extra tests
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: |
+        sapi/cli/php run-extra-tests.php

--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -3,6 +3,9 @@ inputs:
   configurationParameters:
     default: ''
     required: false
+  runExtraTests:
+    default: false
+    required: false
 runs:
   using: composite
   steps:
@@ -16,6 +19,8 @@ runs:
         # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269889
         prepare: |
           cd $GITHUB_WORKSPACE
+
+          OPCACHE_TLS_TESTS_DEPS="gcc"
 
           kldload accf_http
           pkg install -y \
@@ -41,9 +46,11 @@ runs:
             webp \
             libavif \
             `#sqlite3` \
-            curl
+            curl \
+            $OPCACHE_TLS_TESTS_DEPS
 
           ./buildconf -f
+          CC=clang CXX=clang++ \
           ./configure \
             --prefix=/usr/local \
             --enable-debug \
@@ -106,3 +113,7 @@ runs:
             --show-slow 1000 \
             --set-timeout 120 \
             -d zend_extension=opcache.so
+
+          if test "${{ inputs.runExtraTests }}" = "true"; then
+            sapi/cli/php run-extra-tests.php
+          fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -361,8 +361,6 @@ jobs:
             -d opcache.enable_cli=1
       - name: Extra tests
         uses: ./.github/actions/extra-tests
-        with:
-          debug: ${{ matrix.debug }}
       - name: Notify Slack
         if: failure()
         uses: ./.github/actions/notify-slack

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,6 +134,8 @@ jobs:
             --asan -x
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
+      - name: Extra tests
+        uses: ./.github/actions/extra-tests
       - name: Notify Slack
         if: failure()
         uses: ./.github/actions/notify-slack
@@ -266,6 +268,8 @@ jobs:
             ${{ matrix.run_tests_parameters }}
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
+      - name: Extra tests
+        uses: ./.github/actions/extra-tests
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
       - name: Notify Slack
@@ -355,6 +359,10 @@ jobs:
             ${{ matrix.run_tests_parameters }}
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
+      - name: Extra tests
+        uses: ./.github/actions/extra-tests
+        with:
+          debug: ${{ matrix.debug }}
       - name: Notify Slack
         if: failure()
         uses: ./.github/actions/notify-slack
@@ -414,6 +422,8 @@ jobs:
           runTestsParameters: >-
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
+      - name: Extra tests
+        uses: ./.github/actions/extra-tests
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
       - name: Notify Slack
@@ -1076,3 +1086,4 @@ jobs:
         with:
           configurationParameters: >-
             --${{ matrix.zts && 'enable' || 'disable' }}-zts
+          runExtraTests: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           runTestsParameters: >-
             --asan -x
+      - name: Extra tests
+        uses: ./.github/actions/extra-tests
   ALPINE:
     if: inputs.run_alpine
     name: ALPINE_X64_ASAN_UBSAN_DEBUG_ZTS

--- a/run-extra-tests.php
+++ b/run-extra-tests.php
@@ -1,0 +1,123 @@
+#!/usr/bin/env php
+<?php
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+ */
+
+/* This is a single entrypoint for non-phpt tests. */
+
+class Environment
+{
+    public function __construct(
+        public string $os,
+        public string $cpuArch,
+        public bool $zts,
+        public bool $debug,
+        public bool $githubAction,
+    ) {}
+}
+
+function show_usage(): void
+{
+    echo <<<HELP
+    Synopsis:
+        php run-extra-tests.php
+
+    Environment variables:
+        TEST_PHP_OS:       One of 'Windows NT', 'Linux', 'FreeBSD', 'Darwin'
+        TEST_PHP_CPU_ARCH: One of 'x86', 'x86_64', 'aarch64'
+
+    HELP;
+}
+
+function main(int $argc, array $argv): void
+{
+    if ($argc !== 1) {
+        show_usage();
+        exit(1);
+    }
+
+    $environment = new Environment(
+        detect_os(),
+        detect_cpu_arch(),
+        PHP_ZTS,
+        PHP_DEBUG,
+        getenv('GITHUB_ACTIONS') === 'true',
+    );
+
+    echo "=====================================================================\n";
+    echo "OS:       {$environment->os}\n";
+    echo "CPU Arch: {$environment->cpuArch}\n";
+    echo "ZTS:      " . ($environment->zts ? 'Yes' : 'No') . "\n";
+    echo "DEBUG:    " . ($environment->debug ? 'Yes' : 'No') . "\n";
+    echo "=====================================================================\n";
+
+    echo "No tests in this branch yet.\n";
+
+    echo "All OK\n";
+}
+
+function output_group_start(Environment $environment, string $name): void
+{
+    if ($environment->githubAction) {
+        printf("::group::%s\n", $name);
+    } else {
+        printf("%s\n", $name);
+    }
+}
+
+function output_group_end(Environment $environment): void
+{
+    if ($environment->githubAction) {
+        printf("::endgroup::\n");
+    }
+}
+
+/**
+ * Returns getenv('TEST_PHP_OS') if defined, otherwise returns one of
+ * 'Windows NT', 'Linux', 'FreeBSD', 'Darwin', ...
+ */
+function detect_os(): string
+{
+    $os = (string) getenv('TEST_PHP_OS');
+    if ($os !== '') {
+        return $os;
+    }
+
+    return php_uname('s');
+}
+
+/**
+ * Returns getenv('TEST_PHP_CPU_ARCH') if defined, otherwise returns one of
+ * 'x86', 'x86_64', 'aarch64', ...
+ */
+function detect_cpu_arch(): string
+{
+    $cpu = (string) getenv('TEST_PHP_CPU_ARCH');
+    if ($cpu !== '') {
+        return $cpu;
+    }
+
+    $cpu = php_uname('m');
+    if (strtolower($cpu) === 'amd64') {
+        $cpu = 'x86_64';
+    } else if (in_array($cpu, ['i386', 'i686'])) {
+        $cpu = 'x86';
+    } else if ($cpu === 'arm64') {
+        $cpu = 'aarch64';
+    }
+
+    return $cpu;
+}
+
+main($argc, $argv);


### PR DESCRIPTION
We are adding extra (non-phpt) test suites in https://github.com/php/php-src/pull/16987 and https://github.com/php/php-src/pull/18939. In order to avoid touching CI files too often (which are maintained in 8.1 and merged in upper branches), we add a single entry point to call the extra tests.

CI files still need to be touched to install dependencies of these tests, but this should be manageable as these do not change often and are the same in every branch.